### PR TITLE
FIX light not turning red during outage

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -201,6 +201,73 @@ func TestAlertLogic(t *testing.T) {
 			wantState:         lights.YellowState{},
 			wantErr:           true,
 		},
+		{
+			name: "storage outage with web operational",
+			incidents: []types.Incident{
+				{
+					ID:           2,
+					Service:      "storage",
+					PrevState:    "maintenance",
+					CurrentState: "outage",
+					CreatedAt:    "2025-02-20T16:27:39.134631",
+					Incident: types.IncidentDetails{
+						Title:       "Storage Service Outage Detected",
+						Description: "Automated systems detected abnormal behavior in storage service api.",
+						Components:  []string{"api", "server", "database"},
+						URL:        "https://status.joseserver.com/incidents/storage-1740068859",
+					},
+					History: []types.IncidentHistory{
+						{
+							ID:           2,
+							IncidentID:   2,
+							RecordedAt:   "2025-02-20T16:27:39.168785",
+							Service:      "storage",
+							PrevState:    "maintenance",
+							CurrentState: "outage",
+							Incident: types.IncidentDetails{
+								Title:       "Storage Service Outage Detected",
+								Description: "Automated systems detected abnormal behavior in storage service api.",
+								Components:  []string{"api", "server", "database"},
+								URL:        "https://status.joseserver.com/incidents/storage-1740068859",
+							},
+						},
+					},
+				},
+				{
+					ID:           1,
+					Service:      "web",
+					PrevState:    "outage",
+					CurrentState: "operational",
+					CreatedAt:    "2025-02-20T16:27:34.010324",
+					Incident: types.IncidentDetails{
+						Title:       "Unexpected Operational in Web System",
+						Description: "We are investigating reports of operational performance in the web system.",
+						Components:  []string{"load-balancer", "server", "api"},
+						URL:        "https://status.joseserver.com/incidents/web-1740068854",
+					},
+					History: []types.IncidentHistory{
+						{
+							ID:           1,
+							IncidentID:   1,
+							RecordedAt:   "2025-02-20T16:27:34.097130",
+							Service:      "web",
+							PrevState:    "outage",
+							CurrentState: "operational",
+							Incident: types.IncidentDetails{
+								Title:       "Unexpected Operational in Web System",
+								Description: "We are investigating reports of operational performance in the web system.",
+								Components:  []string{"load-balancer", "server", "api"},
+								URL:        "https://status.joseserver.com/incidents/web-1740068854",
+							},
+						},
+					},
+				},
+			},
+			notifiedIncidents: map[int]bool{},
+			startTime:         time.Date(2025, 2, 20, 16, 27, 0, 0, time.UTC),
+			wantState:         lights.RedState{},
+			wantErr:           false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/poll/poll.go
+++ b/poll/poll.go
@@ -119,9 +119,21 @@ func AlertLogic(incidents []types.Incident, light lights.Light, notifiedIncident
 
 	// Sort incidents by creation time, most recent first
 	sortedIncidents := sortIncidentsByTime(incidents)
-	mostRecent := sortedIncidents[0]
 
-	// First check for any unnotified critical incidents
+	// Check if most recent incident is in normal state
+	if len(sortedIncidents) > 0 {
+		mostRecent := sortedIncidents[0]
+		createdAt, err := parseIncidentTime(mostRecent)
+		if err != nil {
+			return lights.YellowState{}, fmt.Errorf("error parsing incident time: %s", err.Error())
+		}
+
+		if createdAt.After(startTime) && isNormalState(mostRecent.CurrentState) {
+			return lights.GreenState{}, nil
+		}
+	}
+
+	// Then check for any unnotified critical incidents
 	for _, incident := range sortedIncidents {
 		createdAt, err := parseIncidentTime(incident)
 		if err != nil {

--- a/poll/poll.go
+++ b/poll/poll.go
@@ -121,18 +121,7 @@ func AlertLogic(incidents []types.Incident, light lights.Light, notifiedIncident
 	sortedIncidents := sortIncidentsByTime(incidents)
 	mostRecent := sortedIncidents[0]
 
-	// First check the most recent incident
-	createdAt, err := parseIncidentTime(mostRecent)
-	if err != nil {
-		return lights.YellowState{}, fmt.Errorf("error parsing incident time: %s", err.Error())
-	}
-
-	if createdAt.After(startTime) && isNormalState(mostRecent.CurrentState) {
-		fmt.Printf("Notification not sent for incident: %s [%s]\n", mostRecent.Incident.Title, mostRecent.CurrentState)
-		return lights.GreenState{}, nil
-	}
-
-	// Then check for any unnotified critical incidents
+	// First check for any unnotified critical incidents
 	for _, incident := range sortedIncidents {
 		createdAt, err := parseIncidentTime(incident)
 		if err != nil {


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add a new test case to verify that the light changes to red during storage outages alongside operational web services, and update the `AlertLogic` function to prioritize detecting critical incidents over merely checking the most recent incident.

### Why are these changes being made?
Previously, the alert system's logic erroneously prioritized the state of the most recent incident over broader system outages, leading to cases where critical incidents were not reflected correctly, such as a storage outage. The updated logic ensures that critical, unnotified incidents trigger the appropriate alert, preventing potential oversight of major issues despite incident recency, thus enhancing system robustness and reliability in crisis situations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined the alert assessment process to enhance detection of critical service conditions for more reliable notifications.
- **Tests**
	- Expanded test coverage with a new scenario evaluating alert logic during a storage outage while the web service remains operational.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->