### PR TITLE
FEAT log color of light at startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,8 +76,6 @@ func main() {
 	}
 	defer cleanup()
 
-	light.Clear()
-
 	fmt.Println("Yellow light on for 2 seconds")
 	light.Blink(lights.StateYellow)
 	time.Sleep(2 * time.Second)
@@ -106,18 +104,31 @@ func main() {
 }
 
 func initializeLight(logger *types.Logger) (lights.Light, func(), error) {
+	var light lights.Light
+	var cleanup func()
+
 	// Try to initialize BLINK1MK3 first
 	if blink1Light, err := lights.NewBlink1Light(); err == nil {
 		fmt.Println("Using BLINK1MK3 light")
 		logger.InfoLog.Printf("Using BLINK1MK3 light")
-		return blink1Light, func() {
+		light = blink1Light
+		cleanup = func() {
 			blink1Light.Close()
-		}, nil
+		}
+	} else {
+		// Fall back to SerialLight
+		fmt.Println("BLINK1MK3 not found, using SerialLight")
+		logger.InfoLog.Printf("BLINK1MK3 not found, using SerialLight")
+		light = lights.NewSerialLight("/dev/ttyUSB0", 9600)
+		cleanup = func() {}
 	}
 
-	// Fall back to SerialLight
-	fmt.Println("BLINK1MK3 not found, using SerialLight")
-	logger.InfoLog.Printf("BLINK1MK3 not found, using SerialLight")
-	serialLight := lights.NewSerialLight("/dev/ttyUSB0", 9600)
-	return serialLight, func() {}, nil
+	// Initialize to green state
+	initialState := lights.GreenState{}
+	if err := initialState.Apply(light); err != nil {
+		return nil, nil, fmt.Errorf("failed to set initial light state: %w", err)
+	}
+	logger.InfoLog.Printf("Light initialized to green")
+
+	return light, cleanup, nil
 }

--- a/main.go
+++ b/main.go
@@ -119,8 +119,16 @@ func initializeLight(logger *types.Logger) (lights.Light, func(), error) {
 		// Fall back to SerialLight
 		fmt.Println("BLINK1MK3 not found, using SerialLight")
 		logger.InfoLog.Printf("BLINK1MK3 not found, using SerialLight")
-		light = lights.NewSerialLight("/dev/ttyUSB0", 9600)
-		cleanup = func() {}
+		serialLight, err := lights.NewSerialLight("/dev/ttyUSB0", 9600)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to initialize SerialLight: %w", err)
+		}
+		light = serialLight
+		cleanup = func() {
+			if err := serialLight.Close(); err != nil {
+				logger.ErrorLog.Printf("Error closing SerialLight: %s", err.Error())
+			}
+		}
 	}
 
 	// Initialize to green state


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Log the color of the light at startup and initialize it to the green state by default.

### Why are these changes being made?

These changes enhance visibility by logging the light setup process and ensure consistent initial behavior by setting the light to green, resolving issues with uninitialized states and improving debugging by providing explicit feedback on which light type is being used.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The lighting system now powers up with a consistent default configuration, ensuring a more dependable startup experience.
  - Enhanced connection management for the `SerialLight`, allowing for persistent connections and improved efficiency.

- **Refactor**
  - Streamlined the initialization and fallback processes for improved reliability and efficiency in light control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->