### PR TITLE
FIX ensure releases are set alongwith the latest tag

### DIFF
--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -1,27 +1,31 @@
-name: Create Semantic Version Tag
+name: Create Release with Assets
 
 on:
   push:
     branches:
       - master
-      - main  # Including both master and main for flexibility
+      - main
 
 jobs:
-  tag-version:
+  create-release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # Needed for creating tags
-
+      contents: write
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch all history for proper versioning
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
 
       - name: Get latest tag
         id: get-latest-tag
         run: |
-          # Get the latest tag, default to v0.0.0 if none exists
           latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "Latest tag: $latest_tag"
           echo "latest_tag=$latest_tag" >> $GITHUB_OUTPUT
@@ -30,15 +34,32 @@ jobs:
         id: bump-version
         run: |
           latest_tag=${{ steps.get-latest-tag.outputs.latest_tag }}
-          # Remove 'v' prefix for version manipulation
           version=${latest_tag#v}
-          # Split version into major, minor, patch
           IFS='.' read -r major minor patch <<< "$version"
-          # Increment patch version
           new_patch=$((patch + 1))
           new_version="v$major.$minor.$new_patch"
           echo "New version: $new_version"
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
+
+      - name: Build binaries
+        run: |
+          # Build for various platforms
+          PLATFORMS=("linux/amd64" "linux/arm64" "darwin/amd64" "darwin/arm64" "windows/amd64")
+          for platform in "${PLATFORMS[@]}"
+          do
+            platform_split=(${platform//\// })
+            GOOS=${platform_split[0]}
+            GOARCH=${platform_split[1]}
+            output_name="incident-checker-${{ steps.bump-version.outputs.new_version }}-$GOOS-$GOARCH"
+            if [ $GOOS = "windows" ]; then
+              output_name+=".exe"
+            fi
+            echo "Building for $GOOS/$GOARCH..."
+            GOOS=$GOOS GOARCH=$GOARCH go build -o "dist/$output_name" .
+            if [ $GOOS != "windows" ]; then
+              chmod +x "dist/$output_name"
+            fi
+          done
 
       - name: Create and push tag
         run: |
@@ -47,3 +68,29 @@ jobs:
           git config user.email "actions@github.com"
           git tag -a "$new_version" -m "Release $new_version"
           git push origin "$new_version"
+
+      - name: Create Release
+        id: create-release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.bump-version.outputs.new_version }}
+          name: Release ${{ steps.bump-version.outputs.new_version }}
+          draft: false
+          prerelease: false
+          files: |
+            dist/*
+          body: |
+            ## Release ${{ steps.bump-version.outputs.new_version }}
+            
+            ### Assets
+            - Linux (amd64, arm64)
+            - macOS (amd64, arm64)
+            - Windows (amd64)
+            
+            ### SHA-256 Checksums
+            ```
+            ${{ steps.sha.outputs.hashes }}
+            ```
+            
+            ### Changes
+            - Automated release from master branch


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the GitHub Actions workflow to create a release with assets for each new version tag, including building binaries for multiple platforms and attaching them to the release on GitHub.

### Why are these changes being made?

The change ensures that every new version tag automatically generates a comprehensive release, reducing manual efforts and enhancing the deliverability of assets to end-users for different operating systems. This approach centralizes release management and increases accessibility by providing pre-built binaries directly through GitHub Releases.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the release process to automatically build and package assets for multiple platforms, providing comprehensive release artifacts for easier installation and use.
- **Chores**
  - Streamlined the automation pipeline for creating releases, ensuring that each release is generated with detailed information and consistent asset management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->