### PR TITLE
FIX only log light color when there is a change

### DIFF
--- a/poll/poll.go
+++ b/poll/poll.go
@@ -85,9 +85,6 @@ func PollIncidents(startTime time.Time, light lights.Light, logger *types.Logger
 			}
 		}
 
-		// Log current light color periodically
-		logger.DebugLog.Printf("Current light color: %s", strings.ToUpper(currentLightState))
-
 		time.Sleep(pollInterval)
 	}
 }


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the periodic logging of the current light color from the `PollIncidents` function when there is no change in the light state.

### Why are these changes being made?

This change reduces unnecessary log noise by only logging the light color when a change occurs, which enhances log clarity and efficiency. It ensures the logs are more focused and relevant for monitoring and debugging purposes.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->